### PR TITLE
Updated dependencies to match current versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,9 +29,9 @@
         "lib/postal.preserve.js"
     ],
     "dependencies": {
-        "lodash": "~2.4.1",
-        "conduitjs": "~0.3.0",
-        "postal.js": "~0.10.3"
+        "lodash": "^4.17.4",
+        "conduitjs": "^0.3.3",
+        "postal": "^2.0.4"
     },
     "devDependencies": {
         "jquery": "~1.10.2",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
         "node": ">=0.4.0"
     },
     "dependencies": {
-        "lodash": "~2.4.1",
-        "conduitjs": "~0.3.0",
-        "postal": "~0.10.3"
+        "lodash": "^4.17.4",
+        "conduitjs": "^0.3.3",
+        "postal": "^2.0.5"
     },
     "bundleDependencies": [
         "lodash",


### PR DESCRIPTION
Updated postal, conduitjs and lodash versions to match the most up to date ones.

Updating postal to version 2.x is essencial so that the plugin is applied to the right instance of Postal.
At the moment if an application is using version 2.X of Postal the postal.preserve won't work since it will use it's own postal instance (version 0.x) instead of the existing one (v2.x)